### PR TITLE
Add the immersion project to dashlord

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -63,6 +63,8 @@ urls:
     category: startup
   - url: https://histologe.beta.gouv.fr
     category: startup
+  - url: https://immersion.beta.pole-emploi.fr/
+    category: startup
   - url: https://kelrisks.beta.gouv.fr
     category: startup
   - url: https://lemarche.inclusion.beta.gouv.fr


### PR DESCRIPTION
The project is in the first stages of development and contains mostly demo content, but we'd like to get early feedback from dashlord. We are currently hosted on pole-emploi.fr.