### PR TITLE
fix: disable dependabot and codescan

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -10,8 +10,8 @@ tools:
   nuclei: true
   zap: true
   thirdparties: true
-  dependabot: true
-  codescan: true
+  dependabot: false
+  codescan: false
   updownio: true
   http: true
   nmap: true


### PR DESCRIPTION
not in use on betagouv repos ATM, so we can hide these empty columns