### PR TITLE
feat: add declaration-rgpd module

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -56,7 +56,7 @@ jobs:
           destination: screenshot.jpeg
           width: 1280
           scaleFactor: 0.5
-          
+
       - name: Déclaration a11y
         continue-on-error: true
         timeout-minutes: 10
@@ -112,9 +112,19 @@ jobs:
         continue-on-error: true
         timeout-minutes: 10
         uses: SocialGouv/thirdparties-action@master
+        id: thirdparties
         with:
           url: "${{ matrix.sites.url }}"
           output: "scans/thirdparties.json"
+
+      - name: Déclaration RGPD
+        continue-on-error: true
+        uses: SocialGouv/dashlord-actions/declaration-rgpd@v1
+        if: ${{ matrix.sites.tools['declaration-rgpd'] }}
+        with:
+          thirdparties: ${{ steps.thirdparties.outputs.json }}
+          url: ${{ matrix.sites.url }}
+          output: scans/declaration-rgpd.json
 
       # testssl.sh action needs an hostname to save its output so we build it here
       - name: Extract hostname
@@ -164,7 +174,7 @@ jobs:
           apiKey: ${{ secrets.UPDOWNIO_API_KEY }}
           url: ${{ matrix.sites.url }}
           output: scans/updownio.json
-      
+
       - name: Stats page
         continue-on-error: true
         timeout-minutes: 10
@@ -172,7 +182,7 @@ jobs:
         if: ${{ matrix.sites.tools.stats }}
         with:
           url: ${{ matrix.sites.url }}
-          uri: 'stats'
+          uri: "stats"
           output: scans/stats.json
 
       - name: Dependabot vulnerabilities alerts
@@ -194,7 +204,7 @@ jobs:
           token: ${{ secrets.CODESCANALERTS_TOKEN }}
           repositories: ${{ join(matrix.sites.repositories) }}
           output: scans/codescanalerts.json
-          
+
       - name: Betagouv API scan
         if: ${{ matrix.sites.tools.betagouv }}
         continue-on-error: true
@@ -203,7 +213,7 @@ jobs:
         with:
           id: "${{ matrix.sites.betaId }}"
           output: "scans/betagouv.json"
-          
+
       - uses: SocialGouv/dashlord-actions/save@main
         with:
           url: ${{ matrix.sites.url }}

--- a/dashlord.yml
+++ b/dashlord.yml
@@ -19,6 +19,7 @@ tools:
   http: true
   nmap: true
   declaration-a11y: true
+  declaration-rgpd: true
   stats: true
   betagouv: true
 urls:
@@ -295,7 +296,7 @@ urls:
   - url: https://dora.fabrique.social.gouv.fr/
     category: startup
     repositories:
-      - betagouv/dora-front    
+      - betagouv/dora-front
     tags:
       - dora
       - production
@@ -303,37 +304,37 @@ urls:
   - url: https://api.dora.incubateur.net/ping/
     category: startup
     repositories:
-      - betagouv/dora-back    
+      - betagouv/dora-back
     tags:
       - dora
-      - staging    
+      - staging
     tools:
       lighthouse: false
     betaId: dora
   - url: https://api.dora.fabrique.social.gouv.fr/ping/
-    category: startup  
+    category: startup
     repositories:
-      - betagouv/dora-back  
+      - betagouv/dora-back
     tags:
       - dora
-      - production     
+      - production
     tools:
       lighthouse: false
     betaId: dora
   - url: https://pdf.dora.incubateur.net/ping
-    category: startup  
+    category: startup
     repositories:
-      - betagouv/dora-pdf  
+      - betagouv/dora-pdf
     tags:
       - dora
-      - staging      
+      - staging
     tools:
       lighthouse: false
     betaId: dora
   - url: https://pdf.dora.fabrique.social.gouv.fr/ping
-    category: startup    
+    category: startup
     repositories:
-      - betagouv/dora-pdf    
+      - betagouv/dora-pdf
     tags:
       - dora
       - production


### PR DESCRIPTION
PR pour vous proposer l'intégration d'un nouveau module "declaration-rgpd" dans votre dashlord

La v1 de cette action détecte et scan les URLs de mentions légales et politique de confidentialité pour en analyser le contenu. Déjà implémentée sur le dashlord de La Fabrique, vous pouvez voir ce que ça donne : https://socialgouv.github.io/dashlord-fabrique/

Il est préférable qu'elle soit exécutée après thirdparties-action, pour en récupérer la liste des trackers et checker si ils sont bien cités dans la PC.

L'action est amenée à évoluer pour des analyses plus poussées.

:wave: 