### PR TITLE
add use of check-url-action

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -168,12 +168,14 @@ jobs:
       - name: Stats page
         continue-on-error: true
         timeout-minutes: 10
-        uses: "MTES-MCT/stats-action@main"
+        uses: "betagouv/check-url-action@main"
         if: ${{ matrix.sites.tools.stats }}
         with:
           url: ${{ matrix.sites.url }}
-          uri: 'stats'
-          output: scans/stats.json
+          uri: stats
+          output: stats.json
+          minExpectedRegex: ^stat
+          exactExpectedRegex: ^stats$
 
       - name: Dependabot vulnerabilities alerts
         continue-on-error: true

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           url: ${{ matrix.sites.url }}
           uri: stats
-          output: stats.json
+          output: scans/stats.json
           minExpectedRegex: ^stat
           exactExpectedRegex: ^stats$
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Ces workflows sont également déclenchables manuellement dans l'onglet "Actions
 ## Customisation
 
 - Le fichier [`dashlord.yml`](./dashlord.yml) permet de paramétrer les urls et quelques options du tableau de bord
-- Le workflow [`scans.yml`](./github/workflows/scans.yml) permet d'activer/désactiver certains scanners
-- Le workflow [`report.yml`](./github/workflows/report.yml) permet de modifier le rapport généré en se basant sur [SocialGouv/dashlord-report-action](https://github.com/SocialGouv/dashlord-report-action).
+- Le workflow [`scans.yml`](./.github/workflows/scans.yml) permet d'activer/désactiver certains scanners
+- Le workflow [`report.yml`](./.github/workflows/report.yml) permet de modifier le rapport généré en se basant sur [SocialGouv/dashlord-actions](https://github.com/SocialGouv/dashlord-actions).
 
 ## Outils
 

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -1,0 +1,6 @@
+# Stats
+
+La colonne `stats` est générée de la manière suivante :
+- l'action `scans.yml` fait appel à la Github Action du repository `betagouv/check-url-action@main` (cf. [Job "Stats page"](../.github/workflows/scans.yml))
+    - à partir des paramètres `baseUrl` et `uri`, l'action appelle la route `[url]/[uri]` (cf. [stats-action](https://github.com/betagouv/check-url-action/blob/main/src/index.js))
+    - un fichier `stats.json` est généré, comprenant la note attribuée à cette URL selon certains critères (URI standard, réponse de l'API, etc.)


### PR DESCRIPTION
J'ai changé le lien de l'action de  scan de stats vers https://github.com/betagouv/check-url-action

L'action check-url est plus générique que l'action de stats : on envoie en paramètre de l'action la regex à matcher pour l'URL, l'URL que l'on souhaite taper, et  on reçoit la grade.

On pourra utiliser cette action pour la route budget :)