### PR TITLE
chore(scans): use socialgouv/dashlord-actions/lhci

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -90,13 +90,10 @@ jobs:
       - name: Lighthouse scan
         if: ${{ matrix.sites.tools.lighthouse }}
         continue-on-error: true
-        timeout-minutes: 10
-        uses: treosh/lighthouse-ci-action@v8
+        timeout-minutes: 20
+        uses: SocialGouv/dashlord-actions/lhci@v1
         with:
-          urls: "${{ matrix.sites.url }}"
-          uploadArtifacts: false
-          temporaryPublicStorage: false
-          configPath: "./lighthouserc.json"
+          url: "${{ join(matrix.sites.subpages, ',') }}"
 
       - name: Mozilla HTTP Observatory
         if: ${{ matrix.sites.tools.http }}
@@ -195,6 +192,7 @@ jobs:
           output: scans/stats.json
           minExpectedRegex: ^stat
           exactExpectedRegex: ^stats$
+
       - name: Budget page
         continue-on-error: true
         timeout-minutes: 10


### PR DESCRIPTION
Use @socialgouv/dashlord-actions/lhci

this allow multiple lighthouse scans per startup ([example](https://socialgouv.github.io/dashlord-fabrique/url/www-fabrique-social-gouv-fr/)) and fix issues with self-hosted runners