### PR TITLE
Allégement de la contrainte sur l’URL du budget

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -211,7 +211,6 @@ jobs:
         with:
           url: ${{ steps.betagouv.outputs.budget_url }}
           output: scans/budget_page.json
-          exactExpectedRegex: ^budget$
 
       - name: Open Github repository
         continue-on-error: true


### PR DESCRIPTION
Il ne me semble pas pertinent de favoriser les URLs de pages budgets égales à `/budget`

On veut encourager les startups d’états à publier leurs budgets et une des pistes pour le faire est de leur permettre de publier leurs budgets sur des outils externes comme le pad.