### PR TITLE
Ajout de panoramax

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -739,3 +739,24 @@ urls:
     betaId: eimis
   - url: https://world.openfoodfacts.org/
     category: startup
+  - url: https://panoramax.fr
+    title: Homepage presentation panoramax
+    betaId: panoramax
+    tags:
+      - geocommun
+    tools:
+      # on ne veut pas mettre le design system de l'etat
+      dsfr: false
+    repositories:
+      - panoramax-project/panoramax-website
+  - url: https://panoramax.ign.fr
+    title: Instance panoramax de l'IGN
+    betaId: panoramax
+    tags:
+      - geocommun
+    tools:
+      # on ne veut pas mettre le design system de l'etat
+      dsfr: false
+    docker:
+      - geovisio/api
+      - geovisio/website

--- a/dashlord.yml
+++ b/dashlord.yml
@@ -742,6 +742,7 @@ urls:
   - url: https://panoramax.fr
     title: Homepage presentation panoramax
     betaId: panoramax
+    category: fab-geocommuns
     tags:
       - geocommun
     tools:
@@ -751,6 +752,7 @@ urls:
       - panoramax-project/panoramax-website
   - url: https://panoramax.ign.fr
     title: Instance panoramax de l'IGN
+    category: fab-geocommuns
     betaId: panoramax
     tags:
       - geocommun


### PR DESCRIPTION
Ajoute :
* panoramax.fr le site de présentation du projet panoramax, startup de la fabrique des géocommuns portée par l'IGN
* panoramax.ign.fr, l'instance de panoramax de l'IGN

Je ne sais pas trop si tous les outils seront pertinents, il faudra peut etre en désactiver.