### PR TITLE
Suppression de sparte.beta.gouv.fr

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -472,7 +472,7 @@ urls:
     betaId: homologation
     repositories:
       - betagouv/mon-service-securise
-  - url: https://sparte.beta.gouv.fr
+  - url: https://mondiagartif.beta.gouv.fr
     category: mtes
     betaId: sparte
     tags:

--- a/dashlord.yml
+++ b/dashlord.yml
@@ -472,14 +472,6 @@ urls:
     betaId: homologation
     repositories:
       - betagouv/mon-service-securise
-  - url: https://mondiagartif.beta.gouv.fr
-    category: mtes
-    betaId: sparte
-    tags:
-      - app
-      - production
-    repositories:
-      - MTES-MCT/sparte
   - url: https://signaux-faibles.beta.gouv.fr
     category: dinum
     betaId: signaux-faibles


### PR DESCRIPTION
On passe sur le dashlord MTES https://github.com/MTES-MCT/dashlord/pull/22