### PR TITLE
Add RNB

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -794,7 +794,7 @@ urls:
     category: dinum
     title: Agir
     betaId: france.nation.verte.agir
-  - url: https://rnb.beta.gouv.fr/
+  - url: https://rnb.beta.gouv.fr
     title: Homepage présentation RNB
     betaId: bat-id
     category: fab-geocommuns
@@ -803,5 +803,3 @@ urls:
     repositories:
       - fab-geocommuns/RNB-site
       - fab-geocommuns/RNB-coeur
-    docker:
-      - github.com/fab-geocommuns/RNB-coeur

--- a/dashlord.yml
+++ b/dashlord.yml
@@ -794,3 +794,14 @@ urls:
     category: dinum
     title: Agir
     betaId: france.nation.verte.agir
+  - url: https://rnb.beta.gouv.fr/
+    title: Homepage présentation RNB
+    betaId: bat-id
+    category: fab-geocommuns
+    tags:
+      - geocommun
+    repositories:
+      - fab-geocommuns/RNB-site
+      - fab-geocommuns/RNB-coeur
+    docker:
+      - github.com/fab-geocommuns/RNB-coeur


### PR DESCRIPTION
Bonjour, 

Ajout de https://rnb.beta.gouv.fr/ le site de présentation du projet du Référentiel National des Bâtiments, startup de la fabrique des géocommuns portée par l'IGN

Je ne sais pas à quel point de nombreux outils sont à désactiver. A dispo pour en retirer si besoin. 

Merci ! 


