### PR TITLE
fix: mise à jour de l'url exposition IJ

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -752,7 +752,7 @@ urls:
       stats: false
       dsfr: false
       ecoindex: false
-  - url: https://exposition.inserjeunes.beta.gouv.fr/api
+  - url: https://api.exposition.inserjeunes.beta.gouv.fr
     category: inserjeunes
     betaId: exposition-ij
     title: Exposition des données InserJeunes


### PR DESCRIPTION
Mise à jour de l'url de l'api exposition InserJeunes pour avoir les metrics HTTP