### PR TITLE
Update dashlord.yml - disable zap & nmap modules

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -15,13 +15,13 @@ tools:
   testssl: true
   wappalyzer: true
   nuclei: false
-  zap: true
+  zap: false
   thirdparties: true
   dependabot: false
   codescan: false
   updownio: true
   http: true
-  nmap: true
+  nmap: false
   declaration-a11y: true
   declaration-rgpd: true
   stats: true


### PR DESCRIPTION
The fact of openly publishing information that could assist malicious actors in attacking systems raises real questions in terms of cyber risk management. It would seem more appropriate to only publish certain sensible elements on a private Dashlord space with authentication. requested.

Of course, anyone can run a Zap or nmap scan, but these scans are noisy and detectable. The current state of the beta.gouv.fr instance of Dashlord tends to facilitate attackers by helping them target vulnerable and easily compromisable assets. That's why we're requesting the deactivation of these scans for now.