### PR TITLE
Mise à jour de l'URL de MonServiceSécurisé

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -457,7 +457,7 @@ urls:
   - url: https://mobiville.pole-emploi.fr
     category: pole-emploi
     betaId: mobiville
-  - url: https://www.monservicesecurise.ssi.gouv.fr
+  - url: https://monservicesecurise.cyber.gouv.fr
     category: lab-innov-anssi
     betaId: homologation
     repositories:


### PR DESCRIPTION
... après un passage vers le domaine *.cyber.gouv.fr