### PR TITLE
Ajout Aigle startup

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -864,6 +864,7 @@ urls:
   - url: https://aigle.beta.gouv.fr
     title: Aigle
     betaId: aigle
+    category: fabnum
     tags:
       - intelligence artificielle
       - cabanisation


### PR DESCRIPTION
Mise à jour de la startup Aigle pour ajouter une catégorie
URL : https://aigle.beta.gouv.fr/
CF fiche produit : https://beta.gouv.fr/startups/aigle.html