### PR TITLE
refactor: use anchor to put properties for Lab' ANSSI in common

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -1,3 +1,9 @@
+_lab_anssi: &lab_anssi
+  category: lab-innov-anssi
+  tools:
+    http: false
+    testssl: false
+
 title: DashLord beta.gouv.fr
 description: Bonnes pratiques techniques
 entity: République Française
@@ -513,50 +519,35 @@ urls:
     category: pole-emploi
     betaId: mobiville
   - url: https://monservicesecurise.cyber.gouv.fr
-    category: lab-innov-anssi
+    <<: *lab_anssi
     betaId: homologation
     repositories:
       - betagouv/mon-service-securise
       - betagouv/mon-service-securise-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://monespacenis2.cyber.gouv.fr
-    category: lab-innov-anssi
+    <<: *lab_anssi
     betaId: nis2
     repositories:
       - betagouv/anssi-nis2
-    tools:
-      http: false
-      testssl: false
   - url: https://monaide.cyber.gouv.fr
-    category: lab-innov-anssi
+    <<: *lab_anssi
     betaId: mon-aide-cyber
     repositories:
       - betagouv/mon-aide-cyber
       - betagouv/mon-aide-cyber-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://demainspecialiste.cyber.gouv.fr
-    category: lab-innov-anssi
+    <<: *lab_anssi
     betaId: demain-specialiste-cyber
     repositories:
       - betagouv/anssi-demain-specialiste-cyber
       - betagouv/anssi-demain-specialiste-cyber-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://messervices.cyber.gouv.fr
-    category: lab-innov-anssi
+    <<: *lab_anssi
     betaId: mes-services-cyber
     repositories:
       - betagouv/anssi-portail
       - betagouv/mon-profil-anssi
       - betagouv/mes-services-cyber-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://zerologementvacant.beta.gouv.fr
     category: mtes
     betaId: zero-logement-vacant


### PR DESCRIPTION
:crossed_fingers: I'm crossing my fingers a little that `dashlord` resolves anchor in the same way I tested locally...
But here is what I did to validate the resolved `yaml` and be confident that we kept the same properties:

```
$ git diff --diff-algorithm=patience -- <(yq dashlord.yml.ref) <(yq 'explode(.) | .' dashlord.yml)
diff --git 1/dev/fd/63 2/dev/fd/62
--- 1/dev/fd/63
+++ 2/dev/fd/62
@@ -1,3 +1,8 @@
+_lab_anssi:
+  category: lab-innov-anssi
+  tools:
+    http: false
+    testssl: false
 title: DashLord beta.gouv.fr
 description: Bonnes pratiques techniques
 entity: République Française
@@ -514,49 +519,49 @@ urls:
     betaId: mobiville
   - url: https://monservicesecurise.cyber.gouv.fr
     category: lab-innov-anssi
+    tools:
+      http: false
+      testssl: false
     betaId: homologation
     repositories:
       - betagouv/mon-service-securise
       - betagouv/mon-service-securise-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://monespacenis2.cyber.gouv.fr
     category: lab-innov-anssi
+    tools:
+      http: false
+      testssl: false
     betaId: nis2
     repositories:
       - betagouv/anssi-nis2
-    tools:
-      http: false
-      testssl: false
   - url: https://monaide.cyber.gouv.fr
     category: lab-innov-anssi
+    tools:
+      http: false
+      testssl: false
     betaId: mon-aide-cyber
     repositories:
       - betagouv/mon-aide-cyber
       - betagouv/mon-aide-cyber-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://demainspecialiste.cyber.gouv.fr
     category: lab-innov-anssi
+    tools:
+      http: false
+      testssl: false
     betaId: demain-specialiste-cyber
     repositories:
       - betagouv/anssi-demain-specialiste-cyber
       - betagouv/anssi-demain-specialiste-cyber-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://messervices.cyber.gouv.fr
     category: lab-innov-anssi
+    tools:
+      http: false
+      testssl: false
     betaId: mes-services-cyber
     repositories:
       - betagouv/anssi-portail
       - betagouv/mon-profil-anssi
       - betagouv/mes-services-cyber-journal
-    tools:
-      http: false
-      testssl: false
   - url: https://zerologementvacant.beta.gouv.fr
     category: mtes
     betaId: zero-logement-vacant
```